### PR TITLE
Poll for event logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ ssl.sh
 
 
 # Keep development, localnet and mainnet configuration local.
-client/deployment/development/deployment.go
-client/deployment/sapphirelocalnet/deployment.go
-client/deployment/sapphiremainnet/deployment.go
+*client/deployment/development/deployment.go
+*client/deployment/sapphirelocalnet/deployment.go
+*client/deployment/sapphiremainnet/deployment.go
 
-go.work.sum
+*go.work.sum

--- a/client/log.go
+++ b/client/log.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/dmigwi/dhamana-protocol/client/sapphire"
 	"github.com/dmigwi/dhamana-protocol/client/server"
+	"github.com/dmigwi/dhamana-protocol/client/storage"
 	"github.com/dmigwi/dhamana-protocol/client/utils"
 	"github.com/jrick/logrotate/rotator"
 )
@@ -27,6 +28,7 @@ var (
 	log         = backendLog.Logger("MAIN")
 	serverLog   = backendLog.Logger("SERVER")
 	sapphireLog = backendLog.Logger("SPPHRE")
+	storageLog  = backendLog.Logger("STORE")
 
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
@@ -37,6 +39,7 @@ var (
 func init() {
 	server.UseLogger(serverLog)
 	sapphire.UseLogger(sapphireLog)
+	storage.UseLogger(storageLog)
 }
 
 // logWriter implements an io.Writer that outputs to both standard output and

--- a/client/main.go
+++ b/client/main.go
@@ -24,7 +24,7 @@ func run(ctx context.Context, cancelFunc context.CancelFunc) {
 		return
 	}
 
-	log.Infof("Using data directory: %s", config.DataDirPath)
+	log.Infof("Using data directory=%s", config.DataDirPath)
 
 	// Initialize the logger while creating the data dir if it doesn't exists.
 	if err := initLogRotator(config.DataDirPath, 50); err != nil {

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -52,7 +52,7 @@ func NewServer(ctx context.Context, port uint16, certfile, keyfile, datadir,
 		return nil, utils.ErrCorruptedConfig // network mismatch
 	}
 
-	log.Infof("Running on the network: %q", net)
+	log.Infof("Running on the network=%s", net)
 
 	address := getContractAddress(net)
 	if address == common.HexToAddress("") {
@@ -60,7 +60,7 @@ func NewServer(ctx context.Context, port uint16, certfile, keyfile, datadir,
 		return nil, utils.ErrCorruptedConfig // Address mismatch
 	}
 
-	log.Infof("Deployed contract address found: %q", address.String())
+	log.Infof("Deployed contract address=%s", address.String())
 
 	// query the deployed time.
 	deployedTime := getDeploymentTime(net)
@@ -69,7 +69,7 @@ func NewServer(ctx context.Context, port uint16, certfile, keyfile, datadir,
 		return nil, utils.ErrCorruptedConfig // timestamp mismatch
 	}
 
-	log.Infof("Contract in use was deployed on Date: %q",
+	log.Infof("Contract in use was deployed on Date=%s",
 		deployedTime.Format(utils.FullDateformat))
 
 	// query the deployed transaction hash
@@ -86,7 +86,7 @@ func NewServer(ctx context.Context, port uint16, certfile, keyfile, datadir,
 		return nil, utils.ErrCorruptedConfig // block no mismatch
 	}
 
-	log.Infof("Contract in use was deployed on Tx: %q and block: %d", txHash, blockNo)
+	log.Infof("Contract was deployed on Tx=%s and block=%d", txHash, blockNo)
 
 	// query the network params
 	networkParams, err := utils.GetNetworkConfig(net)
@@ -117,6 +117,10 @@ func NewServer(ctx context.Context, port uint16, certfile, keyfile, datadir,
 			}
 			return crypto.Sign(digest[:], key)
 		})
+	if err != nil {
+		log.Errorf("wrapping the sapphire client failed: %v", err)
+		return nil, err
+	}
 
 	// Create the chat instance to be used.
 	chatInstance, err := contracts.NewChat(address, backend)
@@ -179,7 +183,7 @@ func (s *ServerConfig) Run() error {
 	certPath := filepath.Join(s.datadir, s.tlsCertFile)
 	keyPath := filepath.Join(s.datadir, s.tlsKeyFile)
 
-	log.Infof("Initiating the server on: %q", s.serverURL)
+	log.Infof("Initiating the server on=%s", s.serverURL)
 
 	return srv.ListenAndServeTLS(certPath, keyPath)
 }

--- a/client/server/sync.go
+++ b/client/server/sync.go
@@ -127,6 +127,7 @@ func (s *ServerConfig) SyncData() error {
 	go s.processEvents()
 
 	// ---- Process all the historical events data in a blocking operation ----
+	log.Info("Processing all the historical events data in a blocking operation...")
 
 	// Create a logging ticker timer.
 	ticker := time.NewTicker(loggingInterval)
@@ -143,7 +144,7 @@ func (s *ServerConfig) SyncData() error {
 			// If context is shut during the looping, exit
 			return nil
 		case <-ticker.C:
-			log.Infof("Syncing data from block=%s To target block=%d, events previously processed=%d",
+			log.Infof("Syncing data from block=%d To target block=%d, events processed=%d",
 				filterOpts.FromBlock.Int64(), targetBlock, eventCounter)
 
 			totalEvents += eventCounter
@@ -164,10 +165,11 @@ func (s *ServerConfig) SyncData() error {
 		eventCounter += counter
 	}
 
-	log.Infof("Processed events=%d from start block=%d to target block=%d",
+	log.Infof("Total processed events=%d from start block=%d to target block=%d",
 		totalEvents, syncedBlock, targetBlock)
 
 	// ---Process asynchronously all the future events data, till shutdown ----
+	log.Info("Processing asynchronously all the future events data, till shutdown...")
 
 	// Reset the ticker timer to be used in polling the future events data.
 	ticker.Reset(pollinginterval)
@@ -326,6 +328,7 @@ func (s *ServerConfig) processEvents() {
 			default:
 			eventsDataLoop:
 				for info := range eventsData {
+					log.Debugf("Local method type=%s is being processed", info.method)
 					if err := s.db.SetLocalData(info.method, info.params...); err != nil {
 
 						// clean dirty writes made before on the current block.

--- a/client/storage/db.go
+++ b/client/storage/db.go
@@ -188,6 +188,8 @@ func NewDB(ctx context.Context, port uint16,
 	connInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
 		host, port, user, password, dbname)
 
+	log.Infof("Creating a new database instance with the driver=%s", driverName)
+
 	db, err := sql.Open(driverName, connInfo)
 	if err != nil {
 		log.Errorf("unable to open to %s: err %v", driverName, err)
@@ -199,12 +201,15 @@ func NewDB(ctx context.Context, port uint16,
 		return nil, err
 	}
 
+	log.Info("Confirming that all the database tables exists")
 	for i, stmt := range tablesSQLStmt {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			log.Errorf("creating a table index (%d) failed Error: %v", i, err)
 			return nil, err
 		}
 	}
+
+	log.Infof("Confirmed all the %d tables exists", len(tablesSQLStmt))
 
 	return &DB{
 		db:     db,


### PR DESCRIPTION
Since Events subscription is not supportted on sapphire, we have resulting to polling the filtered logs at regular intervals.
```
2023-08-24 23:46:06.867 [INF] SERVER: Creating a sapphire client wrapped over an eth client
2023-08-24 23:46:08.250 [INF] SERVER: Subscribing to all contract events listeners starting from block 2310736
2023-08-24 23:46:08.250 [ERR] MAIN: SyncData failed error: subscribing to event BondBodyTerms failed Error: notifications not supported
2023-08-24 23:46:08.250 [INF] MAIN: Shutdown sequence successfully completed!
```